### PR TITLE
Prioritize -All Pokemon above +Past etc

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1258,6 +1258,11 @@ export class TeamValidator {
 		}
 		if (banReason === '') return null;
 
+		banReason = ruleTable.check('pokemontag:allpokemon');
+		if (banReason) {
+			return `${species.name} is not in the list of allowed pokemon.`;
+		}
+
 		// obtainability
 		if (tierSpecies.isNonstandard) {
 			banReason = ruleTable.check('pokemontag:' + toID(tierSpecies.isNonstandard));
@@ -1281,11 +1286,6 @@ export class TeamValidator {
 			if (banReason === '') return null;
 		}
 
-		banReason = ruleTable.check('pokemontag:allpokemon');
-		if (banReason) {
-			return `${species.name} is not in the list of allowed pokemon.`;
-		}
-
 		return null;
 	}
 
@@ -1300,6 +1300,11 @@ export class TeamValidator {
 			return `${set.name}'s item ${item.name} is ${banReason}.`;
 		}
 		if (banReason === '') return null;
+
+		banReason = ruleTable.check('pokemontag:allitems');
+		if (banReason) {
+			return `${set.name}'s item ${item.name} is not in the list of allowed items.`;
+		}
 
 		// obtainability
 		if (item.isNonstandard) {
@@ -1324,11 +1329,6 @@ export class TeamValidator {
 			if (banReason === '') return null;
 		}
 
-		banReason = ruleTable.check('pokemontag:allitems');
-		if (banReason) {
-			return `${set.name}'s item ${item.name} is not in the list of allowed items.`;
-		}
-
 		return null;
 	}
 
@@ -1343,6 +1343,11 @@ export class TeamValidator {
 			return `${set.name}'s move ${move.name} is ${banReason}.`;
 		}
 		if (banReason === '') return null;
+
+		banReason = ruleTable.check('pokemontag:allmoves');
+		if (banReason) {
+			return `${set.name}'s move ${move.name} is not in the list of allowed moves.`;
+		}
 
 		// obtainability
 		if (move.isNonstandard) {
@@ -1367,11 +1372,6 @@ export class TeamValidator {
 			if (banReason === '') return null;
 		}
 
-		banReason = ruleTable.check('pokemontag:allmoves');
-		if (banReason) {
-			return `${set.name}'s move ${move.name} is not in the list of allowed moves.`;
-		}
-
 		return null;
 	}
 
@@ -1386,6 +1386,11 @@ export class TeamValidator {
 			return `${set.name}'s ability ${ability.name} is ${banReason}.`;
 		}
 		if (banReason === '') return null;
+
+		banReason = ruleTable.check('pokemontag:allabilities');
+		if (banReason) {
+			return `${set.name}'s ability ${ability.name} is not in the list of allowed abilities.`;
+		}
 
 		// obtainability
 		if (ability.isNonstandard) {
@@ -1403,11 +1408,6 @@ export class TeamValidator {
 				return `${set.name}'s ability ${ability.name} does not exist in this game.`;
 			}
 			if (banReason === '') return null;
-		}
-
-		banReason = ruleTable.check('pokemontag:allabilities');
-		if (banReason) {
-			return `${set.name}'s ability ${ability.name} is not in the list of allowed abilities.`;
 		}
 
 		return null;

--- a/test/sim/team-validator.js
+++ b/test/sim/team-validator.js
@@ -553,6 +553,12 @@ describe('Team Validator', function () {
 		];
 		illegal = TeamValidator.get('gen7ubers@@@-allpokemon,+giratinaaltered').validateTeam(team);
 		assert(illegal);
+
+		team = [
+			{species: 'tyrantrum', ability: 'strongjaw', moves: ['protect'], evs: {hp: 1}},
+		];
+		illegal = TeamValidator.get('gen8nationaldex@@@-allpokemon').validateTeam(team);
+		assert(illegal);
 	});
 
 	it('should allow moves to be banned', function () {


### PR DESCRIPTION
Previously, format bans/unbans were processed in order of "most specific to least specific".

So `+Giratina-Origin` trumps `-Giratina` trumps `+Uber` trumps `-All Pokemon`.

And nonstandard reasons (`Unobtainable`, `Past`, `CAP`, etc) were slotted between `Uber` and `All Pokemon`.

This has the unfortunate effect that if a base ruleset allows a certain normally-banned category of Pokémon, you can't use `-All Pokemon` to whitelist a list of Pokémon.

Moving nonstandard reasons to lowest precedence once again allows `-All Pokemon` to be used as intended.